### PR TITLE
Fix queue system and time on dedicated servers

### DIFF
--- a/gma.lua
+++ b/gma.lua
@@ -99,7 +99,8 @@ function GMA.PrePareFiles(tbl, path, files, async)
 	end
 
 	local identifier = "GMA.PrePareFiles." .. path .. "-" .. CurTime()
-	timer.Create(identifier, 0, 0, function()
+
+    local function queueFunc()
 		if tbl.activeReads >= maxActiveReads then return end
 
 		for _ = 1, maxActiveReads - tbl.activeReads do
@@ -118,7 +119,7 @@ function GMA.PrePareFiles(tbl, path, files, async)
 				end
 			end)
 		end
-	end)
+	end
 
 
 	for _, ffile in ipairs(files) do
@@ -133,7 +134,10 @@ function GMA.PrePareFiles(tbl, path, files, async)
 			tbl.checkfile(ffile, status, data)
 		end
 	end
-	if not async then
+
+    if async then
+        timer.Create(identifier, 0, 0, queueFunc)
+    else
 		tbl.OnFinish(tbl.files)
 	end
 end

--- a/gma.lua
+++ b/gma.lua
@@ -90,13 +90,12 @@ function GMA.PrePareFiles(tbl, path, files, async)
 	tbl.activeReads = 0
 	tbl.checkfile = function(file, status, content, id)
 		if status ~= FSASYNC_OK then
-			ErrorNoHaltWithStack("Failed to read " .. file .. " (Code: " .. tostring(status) .. ")")
-        else
-            tbl.files[file] = {
-                content = content, -- file.Read is slow
-                size = string.len(content) -- file.Size is slow.
-            }
+			error("Failed to read " .. file .. " (Code: " .. tostring(status) .. ")")
         end
+        tbl.files[file] = {
+            content = content, -- file.Read is slow
+            size = string.len(content) -- file.Size is slow.
+        }
 	end
 
 	local identifier = "GMA.PrePareFiles." .. path .. "-" .. CurTime()
@@ -113,12 +112,9 @@ function GMA.PrePareFiles(tbl, path, files, async)
 			file.AsyncRead(nextFile, "GAME", function(_, _, status, content)
 				tbl.activeReads = tbl.activeReads - 1
 
-				local err = tbl.checkfile(nextFile, status, content)
+				tbl.checkfile(nextFile, status, content)
 				if #tbl.queue == 0 and tbl.activeReads == 0 then
 					tbl.OnFinish(tbl.files)
-				end
-				if err then
-					error(err)
 				end
 			end)
 		end
@@ -134,10 +130,7 @@ function GMA.PrePareFiles(tbl, path, files, async)
             if not data then
                 status = FSASYNC_ERR_FILEOPEN
             end
-			local err = tbl.checkfile(ffile, status, data)
-			if err then
-				ErrorNoHaltWithStack(err)
-			end
+			tbl.checkfile(ffile, status, data)
 		end
 	end
 	if not async then

--- a/gma.lua
+++ b/gma.lua
@@ -86,7 +86,6 @@ function GMA.PrePareFiles(tbl, path, files, async)
 
 	tbl.files = {}
 	tbl.queue = {}
-	tbl.async = async
 	tbl.activeReads = 0
 	tbl.checkfile = function(file, status, content, id)
 		if status ~= FSASYNC_OK then

--- a/gma.lua
+++ b/gma.lua
@@ -263,13 +263,13 @@ function GMA.Read(file_path, no_content, path)
 		File content
 	]]
 	if not no_content then
-		for k = 1, #tbl.Files do
+		for k=1, #tbl.Files do
 			local file_tbl = tbl.Files[k]
 			file_tbl.Content = f:Read(file_tbl.Size)
 		end
 	else
 		local skip = 0
-		for k = 1, #tbl.Files do
+		for k=1, #tbl.Files do
 			local file_tbl = tbl.Files[k]
 			skip = skip + file_tbl.Size
 		end

--- a/gma.lua
+++ b/gma.lua
@@ -90,14 +90,13 @@ function GMA.PrePareFiles(tbl, path, files, async)
 	tbl.activeReads = 0
 	tbl.checkfile = function(file, status, content, id)
 		if status ~= FSASYNC_OK then
-			-- return the error, we still need to call OnFinish if the last file failed
-			return "Failed to read " .. file .. " (Code: " .. tostring(status) .. ")"
-		end
-
-		tbl.files[file] = {
-			content = content, -- file.Read is slow
-			size = string.len(content) -- file.Size is slow.
-		}
+			ErrorNoHaltWithStack("Failed to read " .. file .. " (Code: " .. tostring(status) .. ")")
+        else
+            tbl.files[file] = {
+                content = content, -- file.Read is slow
+                size = string.len(content) -- file.Size is slow.
+            }
+        end
 	end
 
 	local identifier = "GMA.PrePareFiles." .. path .. "-" .. CurTime()
@@ -125,6 +124,7 @@ function GMA.PrePareFiles(tbl, path, files, async)
 		end
 	end)
 
+
 	for _, ffile in ipairs(files) do
 		if async then
 			table.insert(tbl.queue, ffile)
@@ -136,7 +136,7 @@ function GMA.PrePareFiles(tbl, path, files, async)
             end
 			local err = tbl.checkfile(ffile, status, data)
 			if err then
-				error(err)
+				ErrorNoHaltWithStack(err)
 			end
 		end
 	end


### PR DESCRIPTION
- use os.time() as a fallback for dedicated servers

- Fix the PrePrepareFiles queue system

In async mode, using indexes as ids would often break because values get shifted down by table.remove
I also added a max concurrent reads which is helpful when creating larger gmas

In sync mode the queue system wouldnt work because table.remove would immediately be called resulting in a queue size of 0 and OnFinish would be called early